### PR TITLE
Adds a marginWidth property to the spinner.

### DIFF
--- a/MMMaterialDesignSpinner.podspec
+++ b/MMMaterialDesignSpinner.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "MMMaterialDesignSpinner"
-  s.version      = "0.2.5"
+  s.version      = "0.2.6"
   s.summary      = "An iOS activity spinner modeled after Google's Material Design spinner"
 
   # This description is used to generate tags and improve search results.

--- a/Pod/Classes/ActivityTracking.h
+++ b/Pod/Classes/ActivityTracking.h
@@ -32,6 +32,13 @@
 /** Sets the line width of the spinner's circle. */
 @property (nonatomic) CGFloat lineWidth;
 
+/**
+ Specifies how much margin the spinner should have from its bounds.
+ Useful when you want to put a background color to the spinner view but the spinner itself draws to the edges.
+ Default is 0.0f
+ */
+@property (nonatomic) CGFloat marginWidth;
+
 /** Sets the line cap of the spinner's circle. */
 @property (nonatomic, strong) NSString * _Nullable lineCap;
 

--- a/Pod/Classes/MMMaterialDesignSpinner.m
+++ b/Pod/Classes/MMMaterialDesignSpinner.m
@@ -25,6 +25,7 @@ static NSString *kMMRingRotationAnimationKey = @"mmmaterialdesignspinner.rotatio
 @synthesize timingFunction=_timingFunction;
 @synthesize duration=_duration;
 @synthesize percentComplete=_percentComplete;
+@synthesize marginWidth=_marginWidth;
 
 - (instancetype)initWithFrame:(CGRect)frame {
     if (self = [super initWithFrame:frame]) {
@@ -73,7 +74,7 @@ static NSString *kMMRingRotationAnimationKey = @"mmmaterialdesignspinner.rotatio
 
 - (CGSize)intrinsicContentSize
 {
-    return CGSizeMake(self.bounds.size.width, self.bounds.size.height);
+    return CGSizeMake(self.bounds.size.width - 2.0f * self.marginWidth, self.bounds.size.height - 2.0f * self.marginWidth);
 }
 
 - (void)tintColorDidChange {
@@ -172,12 +173,15 @@ static NSString *kMMRingRotationAnimationKey = @"mmmaterialdesignspinner.rotatio
 
 - (void)updatePath {
     CGPoint center = CGPointMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds));
-    CGFloat radius = MIN(CGRectGetWidth(self.bounds) / 2, CGRectGetHeight(self.bounds) / 2) - self.progressLayer.lineWidth / 2;
+    CGFloat radius = MIN(
+                         ( CGRectGetWidth(self.bounds) - 2.0f * self.marginWidth ) / 2,
+                         ( CGRectGetHeight(self.bounds) - 2.0f * self.marginWidth ) / 2
+                         ) - self.progressLayer.lineWidth / 2;
     CGFloat startAngle = (CGFloat)(0);
     CGFloat endAngle = (CGFloat)(2*M_PI);
     UIBezierPath *path = [UIBezierPath bezierPathWithArcCenter:center radius:radius startAngle:startAngle endAngle:endAngle clockwise:YES];
     self.progressLayer.path = path.CGPath;
-
+    
     self.progressLayer.strokeStart = 0.f;
     self.progressLayer.strokeEnd = self.percentComplete;
 }


### PR DESCRIPTION
Just that. Adds a `marginWidth` property that adds a margin from the edges of the view.
Useful when you want to have a spinner with a background color which you don't want the animation to hit the edges of the view. Example use (before this pull request, weird drawing):

> MMMaterialDesignSpinner *spinner = [[MMMaterialDesignSpinner alloc] initWithFrame:CGRectMake(self.view.bounds - 32, self.view.bounds - 32, 64, 64);
> spinner.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.6f];
> spinner.lineWidth = 2.0f;
> spinner.tintColor = [UIColor whiteColor];
> [self.view addSubview:spinner];
> [self.view bringSubviewToFront:spinner];
> [spinner startAnimating];

With this pull request, you can set a margin:

> MMMaterialDesignSpinner *spinner = [[MMMaterialDesignSpinner alloc] initWithFrame:CGRectMake(self.view.bounds - 32, self.view.bounds - 32, 64, 64);
> spinner.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.6f];
> spinner.lineWidth = 2.0f;
> spinner.tintColor = [UIColor whiteColor];
> spinner.marginWidth = 16.0f; // <-- HERE
> [self.view addSubview:spinner];
> [self.view bringSubviewToFront:spinner];
> [spinner startAnimating];


**BEFORE**
![img_0056](https://user-images.githubusercontent.com/3308103/28836641-c101774a-76b7-11e7-9bcd-727ed9a86d1c.PNG)

**AFTER**
![img_0057](https://user-images.githubusercontent.com/3308103/28836649-ca2e4ab4-76b7-11e7-9ac9-7963bf1fce9d.PNG)
